### PR TITLE
Update NN - we make the fact signature more expressive

### DIFF
--- a/HopfieldNet/BM/Core.lean
+++ b/HopfieldNet/BM/Core.lean
@@ -40,6 +40,7 @@ open Finset Matrix NeuralNetwork State ENNReal Real PMF
 
 variable {R U : Type} [Field R] [LinearOrder R] [IsStrictOrderedRing R] [DecidableEq U] [Fintype U] [Nonempty U]
 
+omit [IsStrictOrderedRing R] in
 lemma BM_pact_of_HNfact (θ val : R) :
   (fun act : R => act = 1 ∨ act = -1) (HNfact θ val) := by
   unfold HNfact
@@ -48,6 +49,7 @@ lemma BM_pact_of_HNfact (θ val : R) :
   · right; rfl
 
 variable [Coe R ℝ]
+
 
 /--
 `BoltzmannMachine` defines a Boltzmann Machine neural network.
@@ -68,8 +70,7 @@ abbrev BoltzmannMachine (R U : Type) [Field R] [LinearOrder R] [IsStrictOrderedR
   pw := fun w => w.IsSymm ∧ ∀ u, w u u = 0,
   κ1 := fun _ => 0, κ2 := fun _ => 1,
   fnet := fun u w_u pred _ => HNfnet u w_u pred,
-  fact := fun u input θ_vec => HNfact (θ_vec.get 0) input,
-  fout := fun _ act => act,
+  fact := fun u (_current_act_val : R) (net_input_val : R) (θ_vec : Vector R 1) => HNfact (θ_vec.get 0) net_input_val,  fout := fun _ act => act,
   pact := fun act => act = (1 : R) ∨ act = (-1 : R), -- This is the pact for BoltzmannMachine
   hpact := fun _ _ _ _ _ _ _ _ => BM_pact_of_HNfact _ _
 }

--- a/HopfieldNet/DetailedBalance.lean
+++ b/HopfieldNet/DetailedBalance.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2025 Matteo Cipollina. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matteo Cipollina
+-/
+
 import HopfieldNet.Stochastic
 import Mathlib.Analysis.Normed.Field.Instances
 import Mathlib.Data.ENNReal.Basic
@@ -31,8 +37,8 @@ lemma mul_div_cancel_of_ne_zero {α : Type*} [Field α] (a b : α) (h : b ≠ 0)
 
 /-- In a tsum over all neurons, only the neuron where s and s' differ contributes --/
 lemma gibbs_single_site_tsum {R U : Type}
-  [Field R] [LinearOrder R] [IsStrictOrderedRing R] [DecidableEq U] [Fintype U] [HDiv ℕ ℕ ℝ]
-  [Nonempty U] [Coe R ℝ] [Inv ℕ] [CommGroup ℕ] [Field ℕ]
+  [Field R] [LinearOrder R] [IsStrictOrderedRing R] [DecidableEq U] [Fintype U]
+  [Nonempty U] [Coe R ℝ]
   (wθ : Params (HopfieldNetwork R U)) (T : ℝ) (s s' : (HopfieldNetwork R U).State)
   (u : U) (h_diff_at_u : s.act u ≠ s'.act u)
   (h_same_elsewhere : ∀ v : U, v ≠ u → s.act v = s'.act v) :
@@ -86,7 +92,7 @@ lemma gibbs_single_site_tsum {R U : Type}
     of updating u to the new value --/--/
 lemma gibbs_single_site_transition_prob {R U : Type}
   [Field R] [LinearOrder R] [IsStrictOrderedRing R] [DecidableEq U] [Fintype U]
-    [Nonempty U] [Field ℕ] [CommGroup ℕ] [Coe R ℝ] [HDiv ℕ ℕ ℝ] [Inv ℕ]
+    [Nonempty U] [Coe R ℝ]
   (wθ : Params (HopfieldNetwork R U)) (T : ℝ) (s s' : (HopfieldNetwork R U).State)
   (u : U) (h_diff_at_u : s.act u ≠ s'.act u)
   (h_same_elsewhere : ∀ v : U, v ≠ u → s.act v = s'.act v) :
@@ -412,7 +418,7 @@ lemma gibbs_update_single_neuron_formula {R U : Type}
   gibbs_update_single_neuron_prob wθ T s u val hval
 
 lemma gibbs_single_site_transition_explicit {R U : Type}
-  [Field R] [LinearOrder R] [IsStrictOrderedRing R] [DecidableEq U] [Fintype U] [Nonempty U] [Coe R ℝ][HDiv ℕ ℕ ℝ] [CommGroup ℕ] [Field ℕ]
+  [Field R] [LinearOrder R] [IsStrictOrderedRing R] [DecidableEq U] [Fintype U] [Nonempty U] [Coe R ℝ]--[HDiv ℕ ℕ ℝ] [CommGroup ℕ] [Field ℕ]
   (wθ : Params (HopfieldNetwork R U)) (T : ℝ) (s s' : (HopfieldNetwork R U).State)
   (u : U) (h_same_elsewhere : ∀ v : U, v ≠ u → s.act v = s'.act v)
   (_ : θ' (wθ.θ u) = 0) (_ : T > 0) (h_neq : s ≠ s') :

--- a/HopfieldNet/HN/Asym.lean
+++ b/HopfieldNet/HN/Asym.lean
@@ -6,7 +6,6 @@ Authors: Matteo Cipollina
 
 import HopfieldNet.HN.Core
 import Mathlib.LinearAlgebra.Matrix.PosDef
-set_option linter.unusedVariables false
 
 /-!
 # Asymmetric Hopfield Networks
@@ -90,8 +89,7 @@ abbrev AsymmetricHopfieldNetwork (R U : Type) [Field R] [LinearOrder R] [IsStric
   /- The network function for neuron `u`, given weights `w` and predecessor states `pred`. -/
   fnet u w pred _ := HNfnet u w pred
   /- The activation function for neuron `u`, given input and threshold `θ`. -/
-  fact u input θ := HNfact (θ.get 0) input
-  /- The output function, given the activation state `act`. -/
+  fact u (_current_act_val : R) (net_input_val : R) (θ_vec : Vector R 1) := HNfact (θ_vec.get 0) net_input_val  /- The output function, given the activation state `act`. -/
   fout _ act := HNfout act
   /- A predicate that the activation state `act` is either 1 or -1. -/
   pact act := act = 1 ∨ act = -1
@@ -111,12 +109,14 @@ Parameters:
 Returns:
 - A pair (A, S) where A is antisymmetric, S is positive definite, and w = A + S
 -/
-def getAsymmetricDecomposition (wθ : Params (AsymmetricHopfieldNetwork R U))
+noncomputable def getAsymmetricDecomposition (wθ : Params (AsymmetricHopfieldNetwork R U))
     (hw' : ∃ (A S : Matrix U U R), A.IsAntisymm ∧ Matrix.PosDef S ∧ wθ.w = A + S ∧ (∀ i, wθ.w i i ≥ 0)) :
     Matrix U U R × Matrix U U R :=
-  let A := (1/2) • (wθ.w - wθ.w.transpose)
-  let S := (1/2) • (wθ.w + wθ.w.transpose)
-  (A, S)
+  let w := wθ.w
+  let one_half : R := (1 : R) / (2 : R)
+  let A_matrix := one_half • (w - wᵀ)
+  let S_matrix := one_half • (w + wᵀ)
+  (A_matrix, S_matrix)
 
 /--
 Computes the local field for a neuron in an asymmetric Hopfield network.

--- a/HopfieldNet/NN.lean
+++ b/HopfieldNet/NN.lean
@@ -9,7 +9,7 @@ import Mathlib.Data.Vector.Basic
 
 open Mathlib Finset
 
-/--
+/-
 A `NeuralNetwork` models a neural network with:
 
 - `R`: Type for weights and activations.
@@ -34,7 +34,7 @@ structure NeuralNetwork (R U : Type) [Zero R] extends Digraph U where
   /-- Computes the net input to a neuron. -/
   (fnet : ∀ u : U, (U → R) → (U → R) → Vector R (κ1 u) → R)
   /-- Computes the activation of a neuron. -/
-  (fact : ∀ u : U, R → Vector R (κ2 u) → R)
+  (fact : ∀ u : U, R → R → Vector R (κ2 u) → R) -- R_current_activation, R_net_input, params
   /-- Computes the final output of a neuron. -/
   (fout : ∀ _ : U, R → R)
   /-- Predicate on activations. -/
@@ -43,91 +43,62 @@ structure NeuralNetwork (R U : Type) [Zero R] extends Digraph U where
   (pw : Matrix U U R → Prop)
   /-- If all activations satisfy `pact`, then the activations computed by `fact` also satisfy `pact`. -/
   (hpact : ∀ (w : Matrix U U R) (_ : ∀ u v, ¬ Adj u v → w u v = 0) (_ : pw w)
-   (σ : (u : U) → Vector R (κ1 u)) (θ : (u : U) → Vector R (κ2 u)) (act : U → R),
-  (∀ u : U, pact (act u)) → (∀ u : U, pact (fact u (fnet u (w u)
-    (fun v => fout v (act v)) (σ u)) (θ u))))
+   (σ : (u : U) → Vector R (κ1 u)) (θ : (u : U) → Vector R (κ2 u)) (current_neuron_activations : U → R),
+  (∀ u_idx : U, pact (current_neuron_activations u_idx)) → -- Precondition on all current activations
+  (∀ u_target : U, pact (fact u_target (current_neuron_activations u_target) -- Pass current_act of target neuron
+                               (fnet u_target (w u_target) (fun v => fout v (current_neuron_activations v)) (σ u_target))
+                               (θ u_target))))
+
 
 variable {R U : Type} [Zero R]
 
 /-- `Params` is a structure that holds the parameters for a neural network `NN`. -/
 structure Params (NN : NeuralNetwork R U) where
-  /-- The weight matrix of the neural network. -/
   (w : Matrix U U R)
-  /-- A proof that if two neurons are not connected, then the weight is zero. -/
   (hw : ∀ u v, ¬ NN.Adj u v → w u v = 0)
-  /-- A proof that the weight matrix satisfies a certain property. -/
   (hw' : NN.pw w)
-  /-- A function that assigns a vector to each neuron. -/
   (σ : ∀ u : U, Vector R (NN.κ1 u))
-  /-- A function that assigns another vector to each neuron. -/
   (θ : ∀ u : U, Vector R (NN.κ2 u))
 
 namespace NeuralNetwork
 
-/--
-`State` represents a state in a neural network.
--/
 structure State (NN : NeuralNetwork R U) where
-  /-- A function mapping each neuron to its activation value. -/
   act : U → R
-  /-- A proof that the activations satisfy the required properties. -/
   hp : ∀ u : U, NN.pact (act u)
 
 namespace State
 
 variable {NN : NeuralNetwork R U} (wσθ : Params NN) (s : NN.State)
 
-/-- The output function of a neuron in the neural network. -/
 def out (u : U) : R := NN.fout u (s.act u)
-
-/-- The net function of a neuron in the neural network. -/
 def net (u : U) : R := NN.fnet u (wσθ.w u) (fun v => s.out v) (wσθ.σ u)
-
-/--
-`onlyUi` states that if a neuron `u` is not an input neuron, then its activation is zero.
--/
 def onlyUi : Prop := ∀ u : U, ¬ u ∈ NN.Ui → s.act u = 0
 
 variable [DecidableEq U]
 
-/--
-`Up` updates the activation of neuron `u` in the state.
-If `v` is `u`, it computes the new activation of `u`.
-Otherwise, it keeps the existing activation.
--/
-def Up (u : U) : NeuralNetwork.State NN :=
-  { act := fun v => if v = u then NN.fact u (s.net wσθ u) (wσθ.θ u) else s.act v, hp := by
-      --simp only
-      intro v
-      split
-      · apply NN.hpact
-        intros u' v' hu'v'
-        exact wσθ.hw u' v' hu'v'
-        exact wσθ.hw'
-        exact fun u ↦ s.hp u
-      · apply s.hp}
+def Up {NN_local : NeuralNetwork R U} (s : NN_local.State) (wσθ : Params NN_local) (u_upd : U) : NN_local.State :=
+  { act := fun v => if v = u_upd then
+                      NN_local.fact u_upd (s.act u_upd)
+                        (NN_local.fnet u_upd (wσθ.w u_upd) (fun n => s.out n) (wσθ.σ u_upd))
+                        (wσθ.θ u_upd)
+                    else
+                      s.act v,
+    hp := by
+      intro v_target
+      rw [ite_eq_dite]
+      split_ifs with h_eq_upd_neuron
+      · exact NN_local.hpact wσθ.w wσθ.hw wσθ.hw' wσθ.σ wσθ.θ s.act s.hp u_upd
+      · exact s.hp v_target
+  }
 
-/-- `workPhase` updates the initial state `extu` for each neuron in `uOrder` using `s.Up wσθ u`.
-It starts with `extu` and returns the final state after processing all neurons in `uOrder`. -/
 def workPhase (extu : NN.State) (_ : extu.onlyUi) (uOrder : List U) : NN.State :=
-  uOrder.foldl (fun s u => s.Up wσθ u) extu
+  uOrder.foldl (fun s_iter u_iter => s_iter.Up wσθ u_iter) extu
 
-/-- `seqStates` generates a sequence of states for the neural network.
-- For `n = 0`, it returns the initial state `s`.
-- For `n > 0`, it updates the state at `n - 1` using the neuron from `useq` at `n - 1`. -/
 def seqStates (useq : ℕ → U) : ℕ → NeuralNetwork.State NN
   | 0 => s
-  | n + 1 => .Up wσθ (seqStates useq n) (useq n)
+  | n + 1 => .Up (seqStates useq n) wσθ (useq n)
 
-/-- `isStable` checks if the state `s` remains unchanged after applying `s.Up wσθ` to every neuron `u`. -/
 def isStable : Prop :=  ∀ (u : U), (s.Up wσθ u).act u = s.act u
 
 end State
-
 end NeuralNetwork
-
-/-- Two neurons `u` and `v` are connected in the graph if `w u v` is not zero. -/
-def Matrix.Adj (w : Matrix U U R) : U → U → Prop := fun u v => w u v ≠ 0
-
-/-- `Matrix.w` returns the value of the matrix `w` at position `(u, v)` if `u` and `v` are connected. -/
-def Matrix.w (w : Matrix U U R) : ∀ u v : U, w.Adj u v → R := fun u v _ => w u v


### PR DESCRIPTION
We make the fact signature more expressive, allowing a unified fact signature that can accommodate state-dependent and state-independent activation rules. State-independent rules simply ignore the current_activation argument.
This makes the hpact lemma more directly representative of the fact field for all network types, and makes the foundation more robust for defining diverse neural network architectures, including LSTM/GRU cells where the new state explicitly depends on the old state in complex ways beyond a simple threshold.